### PR TITLE
feat: add toolclub/dsh-agent-team-gui

### DIFF
--- a/data/candidates.json
+++ b/data/candidates.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-08-17T15:45:25.944Z",
+  "updatedAt": "2026-08-17T16:49:17.731Z",
   "candidates": {
     "01virex-dsh-foxy-jumpscare": {
       "id": "01virex-dsh-foxy-jumpscare",
@@ -179079,52 +179079,6 @@
         ]
       },
       "failures": []
-    },
-    "toolclub-dsh-agent-team-gui": {
-      "id": "toolclub-dsh-agent-team-gui",
-      "repository": {
-        "fullName": "toolclub/dsh-agent-team-gui",
-        "url": "https://github.com/toolclub/dsh-agent-team-gui"
-      },
-      "summary": "toolclub/dsh-agent-team-gui",
-      "sources": [
-        "awesome-dsh-plugin",
-        "github-topic"
-      ],
-      "admission": {
-        "status": "candidate"
-      },
-      "lifecycle": {
-        "suggestion": "incubating"
-      },
-      "visibility": "hidden",
-      "discoveredAt": "2026-08-15T06:13:35.772Z",
-      "lastSeenAt": "2026-08-17T07:27:37.165Z",
-      "checks": {
-        "checkedAt": "2026-08-17T06:43:20.788Z",
-        "publicRepository": true,
-        "manifestFound": true,
-        "manifestPath": "package.json:dsh.bundle",
-        "installSpec": "github:toolclub/dsh-agent-team-gui",
-        "installSpecValid": true,
-        "readmeFound": true,
-        "readmeGuidance": true,
-        "relevant": true,
-        "archived": false,
-        "admissionReady": true,
-        "reasons": []
-      },
-      "failures": [],
-      "github": {
-        "stars": 19,
-        "license": "MIT",
-        "archived": false,
-        "private": false,
-        "createdAt": "2026-08-15T03:40:19Z",
-        "lastPushAt": "2026-08-17T03:40:44Z",
-        "latestReleaseAt": "2026-08-17T03:44:01Z",
-        "capturedAt": "2026-08-17T06:43:20.788Z"
-      }
     },
     "torolex-periscope": {
       "id": "torolex-periscope",

--- a/data/catalog-v2.json
+++ b/data/catalog-v2.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-08-17T15:45:25.944Z",
-  "sourceCommit": "b98a0559be3973d1a272353c9d09134e9da4aa724bed859f8cb6549493ef709f",
+  "updatedAt": "2026-08-17T16:49:17.731Z",
+  "sourceCommit": "39fdc95155cee7f38c532f815bd4b56921b468317f79b5f930200d985c7c682c",
   "source": {
     "repository": "Ericwong5021/deepseek-plugin-store",
     "registry": "registry/plugins",
@@ -419,8 +419,8 @@
       }
     ],
     "rankings": {
-      "generatedAt": "2026-08-17T15:45:25.944Z",
-      "eligibleCount": 575,
+      "generatedAt": "2026-08-17T16:49:17.731Z",
+      "eligibleCount": 576,
       "popular": {
         "method": "current-github-stars",
         "limit": 100,
@@ -448,6 +448,7 @@
           "fishquito7-dsh-skill-viewer",
           "laynechai-superpowers-dsh",
           "alingalingling-ui-status-label",
+          "toolclub-dsh-agent-team-gui",
           "awesome-dsh-plugin-dsh-find-plugin",
           "dancingmemory-dskin",
           "chinesezjc-dsh-interconnect",
@@ -523,8 +524,7 @@
           "omdsh-dev-dsh-sidechain",
           "starfie1d1272-dsh-builtin-toggles",
           "thetianzz-dsh-billing",
-          "zjl88858-dsh-huadongbianzuqi",
-          "congchuanling-dot-dsh-telegram-relay"
+          "zjl88858-dsh-huadongbianzuqi"
         ]
       },
       "new": {
@@ -532,6 +532,7 @@
         "windowDays": 30,
         "limit": 100,
         "items": [
+          "toolclub-dsh-agent-team-gui",
           "dsh-market-dsh-market",
           "bowenliang123-dsh-context",
           "jayden-x-l-forkprobe",
@@ -630,14 +631,14 @@
           "hellosky983-dsh-qrcode",
           "hellosky983-dsh-skillradar",
           "heyflyingpig-long-draft-input",
-          "iamlieutenant-dsh-tool-user-memory",
-          "inmny-dsh-git-bash"
+          "iamlieutenant-dsh-tool-user-memory"
         ]
       },
       "active": {
         "method": "latest-github-push",
         "limit": 100,
         "items": [
+          "toolclub-dsh-agent-team-gui",
           "anionex-dsh-vision-toolkit",
           "yyh-001-dsh-expression",
           "yelebai-dsh-plugin-marketplace",
@@ -736,8 +737,7 @@
           "ykennen-dsh-zh-output",
           "lynx-gt-dsh-subagent-cwd",
           "1841220388zzzcccxxx-star-dsh-git-graph",
-          "sanqi-normal-dsh-webui-market-plugin",
-          "zhaoscsc-dsh-wikilink"
+          "sanqi-normal-dsh-webui-market-plugin"
         ]
       },
       "rising": {
@@ -119225,6 +119225,102 @@
     },
     {
       "schemaVersion": 2,
+      "id": "toolclub-dsh-agent-team-gui",
+      "displayName": "dsh-agent-team-gui",
+      "repository": {
+        "fullName": "toolclub/dsh-agent-team-gui",
+        "url": "https://github.com/toolclub/dsh-agent-team-gui"
+      },
+      "aliases": [],
+      "summaries": {
+        "zh": "面向 DeepSeek Harness 的持久化多模型 Agent 小队：主 Agent 动态规划、有界 DAG 与审核修复循环、逐成员模型/工具策略、可恢复运行中心，以及基于厂商上报的 Token 洞察。",
+        "en": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights."
+      },
+      "installTargets": [
+        {
+          "type": "github",
+          "spec": "github:toolclub/dsh-agent-team-gui"
+        }
+      ],
+      "classification": {
+        "group": "agents-workflows",
+        "category": "orchestration",
+        "tags": [
+          "agent",
+          "automation",
+          "collaboration",
+          "context",
+          "planning",
+          "tool",
+          "ui",
+          "workflow"
+        ],
+        "source": "accepted-maintainer",
+        "confidence": "high",
+        "evidence": [
+          "issue:https://github.com/Ericwong5021/deepseek-plugin-store/issues/35",
+          "package.json:dsh.bundle"
+        ],
+        "needsReview": false
+      },
+      "admission": {
+        "status": "verified",
+        "evidence": [
+          "package.json:dsh.bundle",
+          "issue:https://github.com/Ericwong5021/deepseek-plugin-store/issues/35"
+        ]
+      },
+      "lifecycle": {
+        "status": "incubating"
+      },
+      "visibility": "listed",
+      "maintainers": [
+        "lzh19162600626-design"
+      ],
+      "addedAt": "2026-08-17",
+      "observations": {
+        "repository": "toolclub/dsh-agent-team-gui",
+        "github": {
+          "stars": 36,
+          "license": "MIT",
+          "archived": false,
+          "lastPushAt": "2026-08-17T16:11:21Z",
+          "capturedAt": "2026-08-17T16:49:17.731Z",
+          "starHistory": [
+            {
+              "capturedAt": "2026-08-17T16:49:17.731Z",
+              "stars": 36
+            }
+          ]
+        },
+        "compatibility": {
+          "manifestFound": true,
+          "manifestPath": "package.json:dsh.bundle",
+          "npmName": "dsh-agent-team-gui",
+          "installSpec": "github:toolclub/dsh-agent-team-gui",
+          "readmeFound": true,
+          "readmeGuidance": true,
+          "manifestReferencesValid": true,
+          "defaultBranchChecks": "passed",
+          "checkedAt": "2026-08-17T16:49:17.731Z"
+        },
+        "discovery": {
+          "origins": [
+            "issue-submission"
+          ],
+          "firstSeenAt": "2026-08-17T16:49:17.731Z",
+          "lastSeenAt": "2026-08-17T16:49:17.731Z"
+        },
+        "failures": [],
+        "lastSuccessfulAt": "2026-08-17T16:49:17.731Z"
+      },
+      "editorial": {
+        "editorPick": false
+      },
+      "quality": null
+    },
+    {
+      "schemaVersion": 2,
       "id": "tostoevsky-tsienhsueshen",
       "displayName": "TsienHsueShen",
       "repository": {
@@ -148316,10 +148412,10 @@
     }
   ],
   "candidateSummary": {
-    "total": 3640,
-    "checked": 2743,
+    "total": 3639,
+    "checked": 2742,
     "unchecked": 897,
-    "admissionReady": 1896,
-    "hidden": 3640
+    "admissionReady": 1895,
+    "hidden": 3639
   }
 }

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-17T15:45:25.944Z",
-  "sourceCommit": "b98a0559be3973d1a272353c9d09134e9da4aa724bed859f8cb6549493ef709f",
+  "updatedAt": "2026-08-17T16:49:17.731Z",
+  "sourceCommit": "39fdc95155cee7f38c532f815bd4b56921b468317f79b5f930200d985c7c682c",
   "source": {
     "provider": "registry-v2",
     "repository": "Ericwong5021/deepseek-plugin-store",
@@ -5282,6 +5282,59 @@
         "manifestFound": false,
         "manifestPath": null,
         "checkedAt": "2026-08-14T10:30:21.295Z"
+      }
+    },
+    {
+      "fullName": "toolclub/dsh-agent-team-gui",
+      "url": "https://github.com/toolclub/dsh-agent-team-gui",
+      "description": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights.",
+      "stars": 36,
+      "pushedAt": "2026-08-17T16:11:21Z",
+      "license": "MIT",
+      "archived": false,
+      "isPlugin": true,
+      "npmName": "dsh-agent-team-gui",
+      "category": {
+        "id": "workflow-automation",
+        "title": "工作流与自动化 / Workflow & Automation"
+      },
+      "addedAt": "2026-08-17",
+      "slug": "toolclub-dsh-agent-team-gui",
+      "name": "toolclub/dsh-agent-team-gui",
+      "summary": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights.",
+      "tags": [
+        "agent",
+        "automation",
+        "collaboration",
+        "context",
+        "planning",
+        "tool",
+        "ui",
+        "workflow"
+      ],
+      "repositoryUrl": "https://github.com/toolclub/dsh-agent-team-gui",
+      "installSpec": "github:toolclub/dsh-agent-team-gui",
+      "author": "lzh19162600626-design",
+      "featured": false,
+      "status": "active",
+      "source": {
+        "type": "registry-v2",
+        "origins": [
+          "issue-submission"
+        ],
+        "file": "registry/plugins/toolclub-dsh-agent-team-gui.json"
+      },
+      "github": {
+        "stars": 36,
+        "license": "MIT",
+        "lastPushAt": "2026-08-17T16:11:21Z",
+        "archived": false,
+        "capturedAt": "2026-08-17T16:49:17.731Z"
+      },
+      "compatibility": {
+        "manifestFound": true,
+        "manifestPath": "package.json:dsh.bundle",
+        "checkedAt": "2026-08-17T16:49:17.731Z"
       }
     },
     {
@@ -79063,7 +79116,7 @@
     "analyzerVersion": "1",
     "model": "deepseek-v4-flash",
     "analyzedPlugins": 0,
-    "totalPlugins": 1686,
+    "totalPlugins": 1687,
     "updatedAt": null
   }
 }

--- a/data/observations.json
+++ b/data/observations.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-08-17T15:45:25.944Z",
+  "updatedAt": "2026-08-17T16:49:17.731Z",
   "repositories": {
     "01virex-dsh-status-rotator": {
       "repository": "01Virex/dsh-status-rotator",
@@ -46840,6 +46840,42 @@
       },
       "failures": [],
       "lastSuccessfulAt": "2026-08-14T10:30:21.295Z"
+    },
+    "toolclub-dsh-agent-team-gui": {
+      "repository": "toolclub/dsh-agent-team-gui",
+      "github": {
+        "stars": 36,
+        "license": "MIT",
+        "archived": false,
+        "lastPushAt": "2026-08-17T16:11:21Z",
+        "capturedAt": "2026-08-17T16:49:17.731Z",
+        "starHistory": [
+          {
+            "capturedAt": "2026-08-17T16:49:17.731Z",
+            "stars": 36
+          }
+        ]
+      },
+      "compatibility": {
+        "manifestFound": true,
+        "manifestPath": "package.json:dsh.bundle",
+        "npmName": "dsh-agent-team-gui",
+        "installSpec": "github:toolclub/dsh-agent-team-gui",
+        "readmeFound": true,
+        "readmeGuidance": true,
+        "manifestReferencesValid": true,
+        "defaultBranchChecks": "passed",
+        "checkedAt": "2026-08-17T16:49:17.731Z"
+      },
+      "discovery": {
+        "origins": [
+          "issue-submission"
+        ],
+        "firstSeenAt": "2026-08-17T16:49:17.731Z",
+        "lastSeenAt": "2026-08-17T16:49:17.731Z"
+      },
+      "failures": [],
+      "lastSuccessfulAt": "2026-08-17T16:49:17.731Z"
     },
     "tostoevsky-tsienhsueshen": {
       "repository": "Tostoevsky/TsienHsueShen",

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-17T15:45:25.944Z",
-  "sourceCommit": "b98a0559be3973d1a272353c9d09134e9da4aa724bed859f8cb6549493ef709f",
+  "updatedAt": "2026-08-17T16:49:17.731Z",
+  "sourceCommit": "39fdc95155cee7f38c532f815bd4b56921b468317f79b5f930200d985c7c682c",
   "source": {
     "provider": "registry-v2",
     "repository": "Ericwong5021/deepseek-plugin-store",
@@ -5282,6 +5282,59 @@
         "manifestFound": false,
         "manifestPath": null,
         "checkedAt": "2026-08-14T10:30:21.295Z"
+      }
+    },
+    {
+      "fullName": "toolclub/dsh-agent-team-gui",
+      "url": "https://github.com/toolclub/dsh-agent-team-gui",
+      "description": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights.",
+      "stars": 36,
+      "pushedAt": "2026-08-17T16:11:21Z",
+      "license": "MIT",
+      "archived": false,
+      "isPlugin": true,
+      "npmName": "dsh-agent-team-gui",
+      "category": {
+        "id": "workflow-automation",
+        "title": "工作流与自动化 / Workflow & Automation"
+      },
+      "addedAt": "2026-08-17",
+      "slug": "toolclub-dsh-agent-team-gui",
+      "name": "toolclub/dsh-agent-team-gui",
+      "summary": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights.",
+      "tags": [
+        "agent",
+        "automation",
+        "collaboration",
+        "context",
+        "planning",
+        "tool",
+        "ui",
+        "workflow"
+      ],
+      "repositoryUrl": "https://github.com/toolclub/dsh-agent-team-gui",
+      "installSpec": "github:toolclub/dsh-agent-team-gui",
+      "author": "lzh19162600626-design",
+      "featured": false,
+      "status": "active",
+      "source": {
+        "type": "registry-v2",
+        "origins": [
+          "issue-submission"
+        ],
+        "file": "registry/plugins/toolclub-dsh-agent-team-gui.json"
+      },
+      "github": {
+        "stars": 36,
+        "license": "MIT",
+        "lastPushAt": "2026-08-17T16:11:21Z",
+        "archived": false,
+        "capturedAt": "2026-08-17T16:49:17.731Z"
+      },
+      "compatibility": {
+        "manifestFound": true,
+        "manifestPath": "package.json:dsh.bundle",
+        "checkedAt": "2026-08-17T16:49:17.731Z"
       }
     },
     {
@@ -79063,7 +79116,7 @@
     "analyzerVersion": "1",
     "model": "deepseek-v4-flash",
     "analyzedPlugins": 0,
-    "totalPlugins": 1686,
+    "totalPlugins": 1687,
     "updatedAt": null
   }
 }

--- a/registry/plugins/toolclub-dsh-agent-team-gui.json
+++ b/registry/plugins/toolclub-dsh-agent-team-gui.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 2,
+  "id": "toolclub-dsh-agent-team-gui",
+  "displayName": "dsh-agent-team-gui",
+  "repository": {
+    "fullName": "toolclub/dsh-agent-team-gui",
+    "url": "https://github.com/toolclub/dsh-agent-team-gui"
+  },
+  "aliases": [],
+  "summaries": {
+    "zh": "面向 DeepSeek Harness 的持久化多模型 Agent 小队：主 Agent 动态规划、有界 DAG 与审核修复循环、逐成员模型/工具策略、可恢复运行中心，以及基于厂商上报的 Token 洞察。",
+    "en": "Persistent multi-model workflow teams for DeepSeek Harness with dynamic lead planning, bounded DAG execution and review loops, per-agent model and tool policies, recoverable Run Center operations, and provider-reported token insights."
+  },
+  "installTargets": [
+    {
+      "type": "github",
+      "spec": "github:toolclub/dsh-agent-team-gui"
+    }
+  ],
+  "classification": {
+    "group": "agents-workflows",
+    "category": "orchestration",
+    "tags": [
+      "agent",
+      "automation",
+      "collaboration",
+      "context",
+      "planning",
+      "tool",
+      "ui",
+      "workflow"
+    ],
+    "source": "accepted-maintainer",
+    "confidence": "high",
+    "evidence": [
+      "issue:https://github.com/Ericwong5021/deepseek-plugin-store/issues/35",
+      "package.json:dsh.bundle"
+    ],
+    "needsReview": false
+  },
+  "admission": {
+    "status": "verified",
+    "evidence": [
+      "package.json:dsh.bundle",
+      "issue:https://github.com/Ericwong5021/deepseek-plugin-store/issues/35"
+    ]
+  },
+  "lifecycle": {
+    "status": "incubating"
+  },
+  "visibility": "listed",
+  "maintainers": [
+    "lzh19162600626-design"
+  ],
+  "addedAt": "2026-08-17"
+}


### PR DESCRIPTION
## Plugin / 插件

- Repository: https://github.com/toolclub/dsh-agent-team-gui
- Install: github:toolclub/dsh-agent-team-gui
- Release: https://github.com/toolclub/dsh-agent-team-gui/releases/tag/v0.5.0
- Tag: v0.5.0
- Release commit: 6ce4453e087f15ae71e0b5b3ec4d61780c88938b
- Category: Agents & Workflows / Orchestration
- Source issue: #35

## What changed

- Add one verified v2 registry record for toolclub/dsh-agent-team-gui with accurate English and Chinese summaries.
- Promote the existing hidden admission-ready candidate into the public catalog.
- Record current static compatibility evidence and regenerate the deterministic v1/v2 projections.

## Why

The repository is already discovered from both the GitHub dsh-plugin topic and awesome-dsh-plugin, but remains a hidden candidate in this store. It has a public MIT repository, a valid root package.json dsh.bundle, README installation guidance, a tagged v0.5.0 release, and passing default-branch checks.

The built-in intake Agent accepted every plugin and registry check for #35. Its PR creation step was blocked only because the workflow scope gate currently treats its own untracked .plugin-intake/ workspace as an unexpected source change. This PR carries the same generated registry change without modifying the plugin repository.

## Compatibility and product evidence

- DeepSeek Harness Web profile plugin.
- Node.js 22 and 24 verified.
- Root dsh.bundle manifest and all referenced paths verified by the intake Agent.
- Dynamic lead planning, bounded DAG execution and review/repair loops, per-agent model/tool policies, recoverable Run Center operations, and provider-reported token insights.
- Screenshots: https://github.com/toolclub/dsh-agent-team-gui#screenshots
- v0.5 acceptance report: https://github.com/toolclub/dsh-agent-team-gui/blob/main/docs/v0.5-acceptance.md
- Main CI: https://github.com/toolclub/dsh-agent-team-gui/actions/runs/32044212007
- Release preflight: https://github.com/toolclub/dsh-agent-team-gui/actions/runs/32044608769

## Validation

- node scripts/validate-registry.mjs
- node scripts/generate-catalog.mjs --check
- node scripts/validate.mjs
- git diff --check

All passed locally. The repository does not define an npm test script.

Closes #35
