### PR TITLE
Editor Pick 申请：Blank-not-black/dsh-Remote 手机远程控制全家桶

### DIFF
--- a/data/editor-picks.json
+++ b/data/editor-picks.json
@@ -22,5 +22,8 @@
   },
   {
     "repository": "SailingLoong/loongport-dsh"
+  },
+  {
+    "repository": "Blank-not-black/dsh-Remote"
   }
 ]


### PR DESCRIPTION
## 申请编辑精选

- **仓库**：Blank-not-black/dsh-Remote（公开，10★）
- **插件包**：`dsh-remote-plugin`（npm，已发布 0.6.3）
- **简介**：DeepSeek Harness 手机远程控制全家桶——独立零依赖网关 + Android App + 桌面 WebUI：实时会话、文件传输、通知推送、斜杠命令桥接、任务目标管理
- **生态**：已收录于 awesome-dsh-plugin（#712/#915）、vlln/plugin-registry（#11）；自动收录 candidate（data/candidates.json 已有）
- **安装标识**：`dsh plugin --profile <name> add dsh-remote-plugin` 有效
- **授权**：本人为项目作者，有权代表该项目

请维护者审核，感谢！